### PR TITLE
feat: updated constructor to have a `client` parameter

### DIFF
--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -18,34 +18,17 @@ class DropboxDriveFileSystem(AbstractFileSystem):
     token : str
           Generated key by adding a dropbox app in the user dropbox account.
           Needs to be done by the user
-
     """
 
-    def __init__(self, token, *args, **storage_options):
-        super().__init__(token=token, *args, **storage_options)
-        self.token = token
-        self.connect()
+    def __init__(self, token=None, client=None, *args, **storage_options):
+        super().__init__(token=token, client=client, *args, **storage_options)
 
-    def _call(self, _, method="get", path=None, data=None, redirect=True, offset=0, length=None,
-              **kwargs):
-        headers = {"Range": f"bytes={offset}-{offset+length+1}"}
-
-        out = self.session.request(
-            method=method.upper(),
-            url=path,
-            data=data,
-            allow_redirects=redirect,
-            headers=headers
-        )
-        out.raise_for_status()
-        return out
-
-    def connect(self):
-        """ connect to the dropbox account with the given token
-        """
-        self.dbx = dropbox.Dropbox(self.token)
-        self.session = requests.Session()
-        self.session.auth = ("Authorization", self.token)
+        if client is not None:
+            self.dbx = client
+        elif token is not None:
+            self.dbx = dropbox.Dropbox(token)
+        else:
+            raise RuntimeError("You must provide either a token or a dropbox client object.")
 
     def ls(self, path, detail=True, **kwargs):
         """ List objects at path

--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -35,13 +35,31 @@ class DropboxDriveFileSystem(AbstractFileSystem):
 
     def __init__(self, token=None, client=None, *args, **storage_options):
         super().__init__(token=token, client=client, *args, **storage_options)
+        self.connect(token=token, client=client)
 
+    def _call(self, _, method="get", path=None, data=None, redirect=True, offset=0, length=None, **kwargs):
+        headers = {"Range": f"bytes={offset}-{offset+length+1}"}
+
+        out = self.session.request(
+            method=method.upper(),
+            url=path,
+            data=data,
+            allow_redirects=redirect,
+            headers=headers
+        )
+        out.raise_for_status()
+        return out
+
+    def connect(self, token=None, client=None):
         if client is not None:
             self.dbx = client
         elif token is not None:
             self.dbx = dropbox.Dropbox(token)
         else:
-            raise RuntimeError("You must provide either a token or a dropbox client object.")
+            raise ValueError("You must provide either a token or a dropbox client object.")
+
+        self.session = requests.Session()
+        self.session.auth = ("Authorization", self.dbx._oauth2_access_token)
 
     def ls(self, path, detail=True, **kwargs):
         """ List objects at path

--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -18,6 +18,19 @@ class DropboxDriveFileSystem(AbstractFileSystem):
     token : str
           Generated key by adding a dropbox app in the user dropbox account.
           Needs to be done by the user
+    client : Dropbox
+          Instead of passing a token, you can give a instance of a Dropbox class.
+          This is useful when using the Dropbox Business API.
+
+    Example:
+    -------
+    ```python
+    import dropbox
+    from dropboxdrivefs import DropboxDriveFileSystem
+
+    dbx = dropbox.DropboxTeam(...)
+    fs = DropboxDriveFileSystem(client=dbx.as_user(...))
+    ```
     """
 
     def __init__(self, token=None, client=None, *args, **storage_options):


### PR DESCRIPTION
## Description
This **PR** updates the constructor of the `DropboxDriveFileSystem` class to include a new parameter named `client`. When creating a new instance, the user must provide either a token (like before) or a **Dropbox** instance. 

## Tasks
- [x] Add a `client` parameter to the `DropboxDriveFileSystem` constructor
- [x] Update the docstring for the  `DropboxDriveFileSystem` constructor

## Notes
~~I also took the liberty of removing the `connect` and `_call` method from `DropboxDriveFileSystem`. The `_call` method was not used and the `connect` method was simple, so I decided to include it directly in the constructor.~~