### PR TITLE
feature: add copy method

### DIFF
--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -1,6 +1,4 @@
 import logging
-import os.path
-
 import dropbox.files
 import requests
 from dropbox.exceptions import ApiError
@@ -177,7 +175,7 @@ class DropboxDriveFileSystem(AbstractFileSystem):
         else:
             return metadata.path_display
         
-    def copy(self, path1, path2, recursive=True, **kwargs):
+    def copy(self, path1, path2, recursive=True, on_error=None, **kwargs):
         """ Copy objects from path1 to path2
         Parameters:
         ----------
@@ -186,23 +184,46 @@ class DropboxDriveFileSystem(AbstractFileSystem):
         path2: a folder or a file
         recursive: bool
             whether to copy files in a folder recursively.
+        on_error : "raise", "ignore"
+            If raise, any not-found exceptions will be raised; if ignore any
+            not-found exceptions will cause the path to be skipped; defaults to
+            raise unless recursive is true, where the default is ignore
         """
+        if on_error is None and recursive:
+            on_error = "ignore"
+        elif on_error is None:
+            on_error = "raise"
         if isinstance(path1, list):
             for file_path in path1:
-                assert not file_path.endswith('/'), 'multiple file copy should takes files as input'
-                self.copy(file_path, path2)
+                if on_error == 'raise':
+                    assert not file_path.endswith('/'), 'multiple file copy should takes files as input'
+                try:
+                    self.copy(file_path, path2)
+                except BaseException as e:
+                    if on_error == 'raise':
+                        raise e
         else:
             if path1.endswith('/') and path2.endswith('/'):
-                assert recursive, 'recursive should be True for folder copying'
+                if on_error == 'raise':
+                    assert recursive, 'recursive should be True for folder copying'
                 if not self.exists(path2[:-1]):
-                    self.dbx.files_copy(path1[:-1], path2[:-1])
+                    path1 = path1[:-1]
+                    path2 = path2[:-1]
                 else:
-                    self.rm(path2[:-1], recursive=True)
-                    self.dbx.files_copy(path1[:-1], path2[:-1])
+                    try:
+                        self.rm(path2[:-1], recursive=True)
+                    except BaseException as e:
+                        if on_error == 'raise':
+                            raise e
+                    path1 = path1[:-1]
+                    path2 = path2[:-1]
             elif path2.endswith('/'):
-                self.dbx.files_copy(path1, path2 + path1.split('/')[-1])
-            else:
+                path2 = path2 + path1.split('/')[-1]
+            try:
                 self.dbx.files_copy(path1, path2)
+            except BaseException as e:
+                if on_error == 'raise':
+                    raise e
 
 class DropboxDriveFile(AbstractBufferedFile):
     """ fetch_all, fetch_range, and read method are based from the http implementation

--- a/dropboxdrivefs/core.py
+++ b/dropboxdrivefs/core.py
@@ -176,7 +176,33 @@ class DropboxDriveFileSystem(AbstractFileSystem):
                 return {"name": metadata.path_display, "size": None, "type": None}
         else:
             return metadata.path_display
-
+        
+    def copy(self, path1, path2, recursive=True, **kwargs):
+        """ Copy objects from path1 to path2
+        Parameters:
+        ----------
+        path1: a folder or file, or a list of folders or files
+            should we add the metadate with the path
+        path2: a folder or a file
+        recursive: bool
+            whether to copy files in a folder recursively.
+        """
+        if isinstance(path1, list):
+            for file_path in path1:
+                assert not file_path.endswith('/'), 'multiple file copy should takes files as input'
+                self.copy(file_path, path2)
+        else:
+            if path1.endswith('/') and path2.endswith('/'):
+                assert recursive, 'recursive should be True for folder copying'
+                if not self.exists(path2[:-1]):
+                    self.dbx.files_copy(path1[:-1], path2[:-1])
+                else:
+                    self.rm(path2[:-1], recursive=True)
+                    self.dbx.files_copy(path1[:-1], path2[:-1])
+            elif path2.endswith('/'):
+                self.dbx.files_copy(path1, path2 + path1.split('/')[-1])
+            else:
+                self.dbx.files_copy(path1, path2)
 
 class DropboxDriveFile(AbstractBufferedFile):
     """ fetch_all, fetch_range, and read method are based from the http implementation

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -8,7 +8,7 @@ from dropboxdrivefs import DropboxDriveFileSystem
 
 @pytest.fixture
 def dropbox_fs():
-    fs = DropboxDriveFileSystem('/')
+    fs = DropboxDriveFileSystem('123')
     if not fs.exists('/source'):
         fs.mkdir('/source')
     if not fs.exists('/source/subdir'):

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -1,0 +1,69 @@
+"""
+Testing Copy Method of DropboxDriveFileSystem
+
+Test case reference from https://filesystem-spec.readthedocs.io/en/latest/copying.html
+"""
+import pytest
+from dropboxdrivefs import DropboxDriveFileSystem
+
+@pytest.fixture
+def dropbox_fs():
+    fs = DropboxDriveFileSystem('/')
+    if not fs.exists('/source'):
+        fs.mkdir('/source')
+    if not fs.exists('/source/subdir'):
+        fs.mkdir('/source/subdir')
+    if not fs.exists('/target'):
+        fs.mkdir('/target')
+    with fs.open('/source/subdir/subfile1', 'w') as f:
+        f.write('hello')
+    with fs.open('/source/file1', 'w') as f:
+        f.write('hello')
+    with fs.open('/source/file2', 'w') as f:
+        f.write('hello')
+    return fs
+
+def test_db_cp(dropbox_fs):
+    try:
+        # 1f. Directory to new directory
+        dropbox_fs.cp("/source/subdir/", "/target/newdir/", recursive=True)
+        assert dropbox_fs.exists('/target/newdir/subfile1')
+        dropbox_fs.rm('/target/newdir', recursive=True)
+        # 1e. Directory to existing directory
+        dropbox_fs.cp("/source/subdir/", "/target/", recursive=True)
+        assert dropbox_fs.exists('/target/subfile1')
+        dropbox_fs.rm('/target/subfile1')
+        # 1a. File to existing directory
+        dropbox_fs.cp('/source/subdir/subfile1', '/target/')
+        assert dropbox_fs.exists('/target/subfile1')
+        dropbox_fs.rm('/target/subfile1')
+        # 1b. File to new directory
+        dropbox_fs.cp('/source/subdir/subfile1', '/target/newdir/')
+        assert dropbox_fs.exists('/target/newdir/subfile1')
+        dropbox_fs.rm('/target/newdir', recursive=True)
+        # 1c. File to File in existing directory
+        dropbox_fs.cp("/source/subdir/subfile1", "/target/newfile")
+        assert dropbox_fs.exists('/target/newfile')
+        dropbox_fs.rm('/target/newfile')
+        # 1d. File to File in new directory
+        dropbox_fs.cp("/source/subdir/subfile1", "/target/newdir/newfile")
+        assert dropbox_fs.exists('/target/newdir/newfile')
+        dropbox_fs.rm('/target/newdir', recursive=True)
+        # 2a. List of Files to existing directory 
+        dropbox_fs.cp(["/source/file1", "/source/file2", "/source/subdir/subfile1"], "/target/")
+        assert dropbox_fs.exists('/target/file1')
+        assert dropbox_fs.exists('/target/file2')
+        assert dropbox_fs.exists('/target/subfile1')
+        dropbox_fs.rm('/target/file1')
+        dropbox_fs.rm('/target/file2')
+        dropbox_fs.rm('/target/subfile1') 
+        # 2b. List of Files to new directory
+        dropbox_fs.cp(["/source/file1", "/source/file2", "/source/subdir/subfile1"], "/target/newdir/")
+        assert dropbox_fs.exists('/target/newdir/file1')
+        assert dropbox_fs.exists('/target/newdir/file2')
+        assert dropbox_fs.exists('/target/newdir/subfile1')
+        dropbox_fs.rm('/target/newdir/', recursive=True)
+    finally:
+        # Final Delete
+        dropbox_fs.rm('/source/', recursive=True)
+        dropbox_fs.rm('/target/', recursive=True)


### PR DESCRIPTION
Adding `copy` method to `DropboxDriveFileSystem`.

The method is tested upon the examples reference from fsspec copy interface definition: https://filesystem-spec.readthedocs.io/en/latest/copying.html. 

The test is written in pytest. Not sure how to convert it to Unittest. 

Please help me rewrite the pytest testing to Unittest testing. 

